### PR TITLE
Use the proper scope for headless param

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -60,7 +60,7 @@ define java::install (
 
     package: {
 
-      $headless_suffix = $java::bool_headless ? {
+      $headless_suffix = $bool_headless ? {
         true    => '-headless',
         default => '',
       }


### PR DESCRIPTION
(Scope(Java::Install[default-jre])) Could not look up qualified variable java::bool_headless; class java has not been evaluated at .../modules/java/manifests/install.pp:63
