### PR TITLE
Allow java::install where package is not empty

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -81,9 +81,9 @@ define java::install (
             /(?i:OpenSuSE)/                                     => "java-1_${version}_0-openjdk-devel",
             /(?i:Solaris)/                                      => "developer/java/jdk-${version}",
             default                   => fail("OperatingSystem ${::operatingsystem} not supported"),
-          },
+          }
+        },
         default => $package,
-        }
       }
 
       $manage_package = $bool_absent ? {


### PR DESCRIPTION
Default selector was for $book_jdk rather than for $package.
